### PR TITLE
Restructure to split ACM downstream deployment connected/disconnected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # JetBrains stuff:
 .idea
+*.iml
 
 # Sphinx documentation
 docs/_build/

--- a/docs/connected-ZTP-flow-hub-deployment.md
+++ b/docs/connected-ZTP-flow-hub-deployment.md
@@ -22,15 +22,18 @@ We will follow the connected diagram we've seen before:
 
 First we need to deploy the OpenShift Hub:
 
-- if you already did this step, continue on [ACM Deployment Connected](#acm-deployment-connected)
-- If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md), then continue on [ACM Deployment Connected](#acm-deployment-connected)
+- if you already did this step, continue on:  
+  - [ACM Deployment Connected](#acm-deployment-connected)
+  - [ACM Deployment Disconnected](/docs/disconnected-ZTP-flow-hub-deployment.md#acm-deployment-in-a-disconnected-environment)
+- If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md), then continue on:
+  - [ACM Deployment Connected](#acm-deployment-connected)
+  - [ACM Deployment Disconnected](/docs/disconnected-ZTP-flow-hub-deployment.md#acm-deployment-in-a-disconnected-environment)
 
 ## ACM Deployment Connected
 
 To do it in a standard way, we just need to go to the OpenShift Marketplace and look for the "Red Hat Advance Cluster Management" operator and trigger the deployment. It will take a while to finish, so please be patient.
 
-
-**NOTE**: If you are from QE, DEV or any Red Hat Associate that want to work with Downstream versions, follow steps below to deploy ACM downstream version:
+**NOTE**: If you are from QE, DEV or any Red Hat Associate that want to work with Downstream versions, you need to ask for permissions for this kind of images in the Slack Channel `#forum-acm`. If you already have permissions to do this, follow steps below to deploy ACM downstream version:
 
 - [ACM downstream deployment connected](prerequirements/acm-downstream-deployment-connected.md) 
 

--- a/docs/connected-ZTP-flow-hub-deployment.md
+++ b/docs/connected-ZTP-flow-hub-deployment.md
@@ -22,7 +22,7 @@ We will follow the connected diagram we've seen before:
 
 First we need to deploy the OpenShift Hub:
 
-- if you already did this step, continue on [ACM Deployment](#acm-deployment-connected)
+- if you already did this step, continue on [ACM Deployment Connected](#acm-deployment-connected)
 - If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md), then continue on [ACM Deployment Connected](#acm-deployment-connected)
 
 ## ACM Deployment Connected

--- a/docs/connected-ZTP-flow-hub-deployment.md
+++ b/docs/connected-ZTP-flow-hub-deployment.md
@@ -15,25 +15,27 @@
 
 # Connected ZTP Flow Hub deployment
 
-In an ideal world, we try to just pull the ACM Operator image from the OperatorHub platform, but here, in the real world, the ACM v2.3.0 is not released yet, so we need to follow [these instructions](https://github.com/open-cluster-management/deploy#lets-get-started) in order to deploy a non-released ACM version.
-
 We will follow the connected diagram we've seen before:
 
 [comment]: <> (TODO: Update ztp-flow-connected.png, specifically the Manifests for Spoke box, with missing arrows to KlusterAddonConfig and ManagedCluster)
 ![](/assets/ztp-flow-connected.png)
 
-But first we need to deploy the OpenShift Hub:
+First we need to deploy the OpenShift Hub:
 
 - if you already did this step, continue on [ACM Deployment](#acm-deployment)
-- If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md)
+- If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md), then continue on [ACM Deployment](#acm-deployment)
 
 ## ACM Deployment
 
 To do it in a standard way, we just need to go to the OpenShift Marketplace and look for the "Red Hat Advance Cluster Management" operator and trigger the deployment. It will take a while to finish, so please be patient.
 
-**NOTE**: If you are from QE, DEV or any Red Hat Associate that want to work with Downstream versions you need to ask for permissions for this kind of images in the Slack Channel `#forum-acm`. If you already have permissions to do this, you will need to do some extra steps **[explained here](/docs/prerequirements/acm-downstream-deployment.md)**.
 
-Once the ACM deployment finishes, the first two steps (Pre-requisites and ACM Deployment) should be already filled, but to be 100% sure, let's check a couple of things (Ensure you have your KUBECONFIG loaded)
+**NOTE**: If you are from QE, DEV or any Red Hat Associate that want to work with Downstream versions, follow steps below to deploy ACM downstream version:
+
+- [ACM downstream deployment connected](prerequirements/acm-downstream-deployment-connected.md) 
+- [ACM downstream deployment disconnected](prerequirements/acm-downstream-deployment-disconnected.md) 
+
+Once ACM downstream deployment is completed, let's check a couple of things (Ensure you have your KUBECONFIG loaded)
 
 ```sh
 oc get HiveConfig -o yaml

--- a/docs/connected-ZTP-flow-hub-deployment.md
+++ b/docs/connected-ZTP-flow-hub-deployment.md
@@ -23,9 +23,9 @@ We will follow the connected diagram we've seen before:
 First we need to deploy the OpenShift Hub:
 
 - if you already did this step, continue on [ACM Deployment](#acm-deployment)
-- If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md), then continue on [ACM Deployment](#acm-deployment)
+- If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md), then continue on [ACM Deployment Connected](#acm-deployment-connected)
 
-## ACM Deployment
+## ACM Deployment Connected
 
 To do it in a standard way, we just need to go to the OpenShift Marketplace and look for the "Red Hat Advance Cluster Management" operator and trigger the deployment. It will take a while to finish, so please be patient.
 
@@ -33,7 +33,6 @@ To do it in a standard way, we just need to go to the OpenShift Marketplace and 
 **NOTE**: If you are from QE, DEV or any Red Hat Associate that want to work with Downstream versions, follow steps below to deploy ACM downstream version:
 
 - [ACM downstream deployment connected](prerequirements/acm-downstream-deployment-connected.md) 
-- [ACM downstream deployment disconnected](prerequirements/acm-downstream-deployment-disconnected.md) 
 
 Once ACM downstream deployment is completed, let's check a couple of things (Ensure you have your KUBECONFIG loaded)
 

--- a/docs/connected-ZTP-flow-hub-deployment.md
+++ b/docs/connected-ZTP-flow-hub-deployment.md
@@ -22,7 +22,7 @@ We will follow the connected diagram we've seen before:
 
 First we need to deploy the OpenShift Hub:
 
-- if you already did this step, continue on [ACM Deployment](#acm-deployment)
+- if you already did this step, continue on [ACM Deployment](#acm-deployment-connected)
 - If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md), then continue on [ACM Deployment Connected](#acm-deployment-connected)
 
 ## ACM Deployment Connected

--- a/docs/disconnected-ZTP-flow-hub-deployment.md
+++ b/docs/disconnected-ZTP-flow-hub-deployment.md
@@ -50,18 +50,20 @@ After going through these steps, we can continue with the typical flow.
 
 But first we need to deploy the OpenShift Hub:
 
-- if you already did this step, continue on [ACM Deployment](#acm-deployment-in-a-disconnected-environment)
+- if you already did this step, continue on [ACM Deployment Disconnected](#acm-deployment-in-a-disconnected-environment)
 - If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md)
 
 ---
 
 ## ACM Deployment in a disconnected Environment
 
-go to the OpenShift Marketplace and look for the "Red Hat Advance Cluster Management" operator and the deploy will start. It takes a while to finish, so please be patience.
+Go to the OpenShift Marketplace and look for the "Red Hat Advance Cluster Management" operator and the deploy will start. It takes a while to finish, so please be patience.
 
-**NOTE**: If you are from QE, DEV or any Red Hat Associate that wanna work with Downstreams versions you need to ask for permissions for this kind of images in the Slack Channel `#forum-acm`. If you already have permissions to do this, you will need to do some extra steps **[explained here](/docs/prerequirements/acm-downstream-deployment-connected.md)**.
+**NOTE**: If you are from QE, DEV or any Red Hat Associate that want to work with Downstream versions, follow steps below to deploy ACM downstream version:
 
-Once the ACM deployment finishes, the first two steps (Pre-requisites and ACM Deployment) should be already filled, but to be 100% sure let's check a couple of things (Ensure you have your KUBECONFIG loaded)
+- [ACM downstream deployment disconnected](prerequirements/acm-downstream-deployment-disconnected.md) 
+
+Once ACM downstream deployment is completed, let's check a couple of things (Ensure you have your KUBECONFIG loaded)
 
 ```yaml
 oc get HiveConfig -o yaml

--- a/docs/disconnected-ZTP-flow-hub-deployment.md
+++ b/docs/disconnected-ZTP-flow-hub-deployment.md
@@ -59,7 +59,7 @@ But first we need to deploy the OpenShift Hub:
 
 go to the OpenShift Marketplace and look for the "Red Hat Advance Cluster Management" operator and the deploy will start. It takes a while to finish, so please be patience.
 
-**NOTE**: If you are from QE, DEV or any Red Hat Associate that wanna work with Downstreams versions you need to ask for permissions for this kind of images in the Slack Channel `#forum-acm`. If you already have permissions to do this, you will need to do some extra steps **[explained here](/docs/prerequirements/acm-downstream-deployment.md)**.
+**NOTE**: If you are from QE, DEV or any Red Hat Associate that wanna work with Downstreams versions you need to ask for permissions for this kind of images in the Slack Channel `#forum-acm`. If you already have permissions to do this, you will need to do some extra steps **[explained here](/docs/prerequirements/acm-downstream-deployment-connected.md)**.
 
 Once the ACM deployment finishes, the first two steps (Pre-requisites and ACM Deployment) should be already filled, but to be 100% sure let's check a couple of things (Ensure you have your KUBECONFIG loaded)
 

--- a/docs/disconnected-ZTP-flow-hub-deployment.md
+++ b/docs/disconnected-ZTP-flow-hub-deployment.md
@@ -50,16 +50,20 @@ After going through these steps, we can continue with the typical flow.
 
 But first we need to deploy the OpenShift Hub:
 
-- if you already did this step, continue on [ACM Deployment Disconnected](#acm-deployment-in-a-disconnected-environment)
-- If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md)
-
+- if you already did this step, continue on:
+  - [ACM Deployment Connected](/docs/connected-ZTP-flow-hub-deployment.md#acm-deployment-connected)
+  - [ACM Deployment Disconnected](/docs/disconnected-ZTP-flow-hub-deployment.md#acm-deployment-in-a-disconnected-environment)
+- If not, please go here and follow the [instructions for the OpenShift Hub Cluster](/docs/prerequirements/ocp4-ipi-deployment.md), then continue on:
+  - [ACM Deployment Connected](/docs/connected-ZTP-flow-hub-deployment.md#acm-deployment-connected)
+  - [ACM Deployment Disconnected](/docs/disconnected-ZTP-flow-hub-deployment.md#acm-deployment-in-a-disconnected-environment)
+  
 ---
 
 ## ACM Deployment in a disconnected Environment
 
-Go to the OpenShift Marketplace and look for the "Red Hat Advance Cluster Management" operator and the deploy will start. It takes a while to finish, so please be patience.
+To do it in a standard way, we just need to go to the OpenShift Marketplace and look for the "Red Hat Advance Cluster Management" operator and the deployment will start. It takes a while to finish, so please be patience.
 
-**NOTE**: If you are from QE, DEV or any Red Hat Associate that want to work with Downstream versions, follow steps below to deploy ACM downstream version:
+**NOTE**: If you are from QE, DEV or any Red Hat Associate that want to work with Downstream versions, you need to ask for permissions for this kind of images in the Slack Channel `#forum-acm`. If you already have permissions to do this, follow steps below to deploy ACM downstream version:
 
 - [ACM downstream deployment disconnected](prerequirements/acm-downstream-deployment-disconnected.md) 
 

--- a/docs/prerequirements/acm-downstream-deployment-connected.md
+++ b/docs/prerequirements/acm-downstream-deployment-connected.md
@@ -1,0 +1,75 @@
+Table of contents:
+
+<!-- TOC depthfrom:1 orderedlist:false -->
+
+- [ACM Downstream Deployment Connected](#acm-downstream-deployment-connected)
+  - [Permission for downstream repo](#permission-for-downstream-repo)
+  - [ACM Downstream deployment](#acm-downstream-deployment)
+  - [ACM Uninstall process](#acm-uninstall-process)
+
+<!-- /TOC -->
+
+# ACM Downstream Deployment Connected
+
+**NOTE**: We are following the same procedure they follow in the `README.md` file from the deployment repository all the things are well explained there, so if you have some doubts that is the right place (even including to [deploy a ACM downstream version](https://github.com/open-cluster-management/deploy#deploying-downstream-builds-snapshots-for-product-quality-engineering) .
+
+## Permission for Downstream Repo
+
+First thing we need to follow the instructions mentioned [here](https://github.com/open-cluster-management/deploy#prepare-to-deploy-open-cluster-management-instance-only-do-once) to request a pull permission for repo **quay.io/acm-d**. 
+
+Then you can verify if you have enough permission:
+
+```sh
+podman pull --authfile ${PULL_SECRET} quay.io/acm-d/acm-custom-registry:2.3.0-DOWNSTREAM-2021-06-13-16-46-23
+```
+
+## ACM Downstream Deployment
+
+To deploy an ACM Downstream version in a connected environment, you will need this repository: **https://github.com/open-cluster-management/deploy**, so clone it and we can continue with the process.
+
+After you clone the repo above, we need to follow these steps:
+
+- Go to the deploy folder, modify file `snapshot.ver` with the snapshot version you want to deploy
+- Then ensure you have 3 PVs (at least) available to be bound
+- Follow these [steps](https://github.com/open-cluster-management/deploy#prepare-to-deploy-open-cluster-management-instance-only-do-once) to prepare the pull-secret.yaml under prereqs folder
+- You will need to export some variables to the Environment
+
+	```sh
+	export KUBECONFIG=<kubeconfig path>
+	export CUSTOM_REGISTRY_REPO=quay.io:443/acm-d
+	export COMPOSITE_BUNDLE=true
+	export DEBUG=true
+	```
+
+	In my case is something like:
+
+	```sh
+	export KUBECONFIG=/home/kni/ipv6/mgmt-hub/auth/kubeconfig
+	export CUSTOM_REGISTRY_REPO=quay.io:443/acm-d
+	export COMPOSITE_BUNDLE=true
+	export DEBUG=true
+	```
+
+- Now we just need to execute the deployment script `start.sh`
+
+	```sh
+	./start.sh --watch
+	```
+
+- When it finishes, we just need to check that all pods are in running state and the installation process take some time to finish so be patient.
+
+	```
+	oc get pods -n open-cluster-management
+	```
+
+- After the installation has finished you need to double-check that the MultiClusterHub object has been annotated with your custom registry repo, otherwise the managed cluster won't be able to pull the required images.
+
+	```sh
+	oc annotate mch multiclusterhub mch-imageRepository='quay.io:443/acm-d'
+	```
+
+## ACM Uninstall Process
+
+In the typical situation, you just need to delete the subscription and that's it but here it's a bit different so be aware.
+
+Using the same deploy repository we've seen before, and with the same variables loaded into the environment we just need to execute the `uninstall.sh` script and eventually it will get uninstalled.

--- a/docs/prerequirements/acm-downstream-deployment-connected.md
+++ b/docs/prerequirements/acm-downstream-deployment-connected.md
@@ -32,41 +32,62 @@ After you clone the repo above, we need to follow these steps:
 - Go to the deploy folder, modify file `snapshot.ver` with the snapshot version you want to deploy
 - Then ensure you have 3 PVs (at least) available to be bound
 - Follow these [steps](https://github.com/open-cluster-management/deploy#prepare-to-deploy-open-cluster-management-instance-only-do-once) to prepare the pull-secret.yaml under prereqs folder
+- Create file icsp.yaml with content below to mirror downstream images to acm-d
+
+    ```yaml
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: ImageContentSourcePolicy
+    metadata:
+      name: rhacm-repo
+    spec:
+      repositoryDigestMirrors:
+      - mirrors:
+        - quay.io:443/acm-d
+        source: registry.redhat.io/rhacm2
+      - mirrors:
+        - registry.redhat.io/openshift4/ose-oauth-proxy
+        source: registry.access.redhat.com/openshift4/ose-oauth-proxy
+    ```
+     Apply it:
+	```shell
+	oc apply -f icsp.yaml
+	```
+
 - You will need to export some variables to the Environment
 
-	```sh
-	export KUBECONFIG=<kubeconfig path>
-	export CUSTOM_REGISTRY_REPO=quay.io:443/acm-d
-	export COMPOSITE_BUNDLE=true
-	export DEBUG=true
-	```
+    ```sh
+    export KUBECONFIG=<kubeconfig path>
+    export CUSTOM_REGISTRY_REPO=quay.io:443/acm-d
+    export COMPOSITE_BUNDLE=true
+    export DEBUG=true
+    ```
 
-	In my case is something like:
+    In my case is something like:
 
-	```sh
-	export KUBECONFIG=/home/kni/ipv6/mgmt-hub/auth/kubeconfig
-	export CUSTOM_REGISTRY_REPO=quay.io:443/acm-d
-	export COMPOSITE_BUNDLE=true
-	export DEBUG=true
-	```
+    ```sh
+    export KUBECONFIG=/home/kni/ipv6/mgmt-hub/auth/kubeconfig
+    export CUSTOM_REGISTRY_REPO=quay.io:443/acm-d
+    export COMPOSITE_BUNDLE=true
+    export DEBUG=true
+    ```
 
 - Now we just need to execute the deployment script `start.sh`
 
-	```sh
-	./start.sh --watch
-	```
+    ```sh
+    ./start.sh --watch
+    ```
 
 - When it finishes, we just need to check that all pods are in running state and the installation process take some time to finish so be patient.
 
-	```
-	oc get pods -n open-cluster-management
-	```
+    ```
+    oc get pods -n open-cluster-management
+    ```
 
 - After the installation has finished you need to double-check that the MultiClusterHub object has been annotated with your custom registry repo, otherwise the managed cluster won't be able to pull the required images.
 
-	```sh
-	oc annotate mch multiclusterhub mch-imageRepository='quay.io:443/acm-d'
-	```
+    ```sh
+    oc annotate mch multiclusterhub mch-imageRepository='quay.io:443/acm-d'
+    ```
 
 ## ACM Uninstall Process
 

--- a/docs/prerequirements/acm-downstream-deployment-disconnected.md
+++ b/docs/prerequirements/acm-downstream-deployment-disconnected.md
@@ -2,22 +2,27 @@ Table of contents:
 
 <!-- TOC depthfrom:1 orderedlist:false -->
 
-- [ACM Downstream Deployment](#acm-downstream-deployment)
+- [ACM Downstream Deployment Disconnected](#acm-downstream-deployment-disconnected)
+  - [Permission for downstream repo](#permission-for-downstream-repo)
   - [ACM Downstream Image Mirroring](#acm-downstream-image-mirroring)
-  - [ACM Downstream deployment](#acm-downstream-deployment-1)
+  - [ACM Downstream deployment](#acm-downstream-deployment)
   - [ACM Uninstall process](#acm-uninstall-process)
 
 <!-- /TOC -->
 
-# ACM Downstream Deployment
+# ACM Downstream Deployment Disconnected
 
-First thing we need to do is ensure we have permissions, to do that you can use this command:
+**NOTE**: We are following the same procedure they follow in the `README.md` file from the deployment repository all the things are well explained there, so if you have some doubts that is the right place (even including to [deploy a ACM downstream version](https://github.com/open-cluster-management/deploy#deploying-downstream-builds-snapshots-for-product-quality-engineering) .
+
+## Permission for Downstream Repo
+
+First thing we need to follow the instructions mentioned [here](https://github.com/open-cluster-management/deploy#prepare-to-deploy-open-cluster-management-instance-only-do-once) to request a pull permission for repo **quay.io/acm-d**. 
+
+Then you can verify if you have enough permission:
 
 ```sh
 podman pull --authfile ${PULL_SECRET} quay.io/acm-d/acm-custom-registry:2.3.0-DOWNSTREAM-2021-06-13-16-46-23
 ```
-
-If that works should be ok to start with the ACM Image Mirroring of downstream bits.
 
 ## ACM Downstream Image Mirroring
 
@@ -86,44 +91,43 @@ Then after that we can execute the script:
 
 To deploy an ACM Downstream version you will need this repository: **https://github.com/open-cluster-management/deploy**, so clone it and we can continue with the process.
 
-**NOTE**: We are following the same procedure they follows in the `README.md` file from the deployment repository all the things are well explained there, so if you have some doubts that is the right place (even including to [deploy a ACM downstream version](https://github.com/open-cluster-management/deploy#deploying-downstream-builds-snapshots-for-product-quality-engineering) .
-
 So now we need to follow these steps:
 
 - After cloning it and enter into the `deploy` folder, you need to modify the file called `snapshot.ver` with the version you wanna deploy
 - Then ensure you have 3 PVs (at least) available to be bound
 - You will need to export some variables to the Environment
 
-```sh
-export DEFAULT_SNAPSHOT="<Desired SNAPSHOT version>"
-export KUBECONFIG=<kubeconfig path>
-export CUSTOM_REGISTRY_REPO=<internal_registry>:<port>/rhacm2
-export COMPOSITE_BUNDLE=true
-export DEBUG=true
-```
+	```sh
+	export DEFAULT_SNAPSHOT="<Desired SNAPSHOT version>"
+	export KUBECONFIG=<kubeconfig path>
+	export CUSTOM_REGISTRY_REPO=<internal_registry>:<port>/rhacm2
+	export COMPOSITE_BUNDLE=true
+	export DEBUG=true
+	```
 
-In my case is something like:
+	In my case is something like:
 
-```sh
-export DEFAULT_SNAPSHOT="2.3.0-DOWNSTREAM-2021-06-16-09-34-33"
-export KUBECONFIG=/home/kni/ipv6/mgmt-hub/auth/kubeconfig
-export CUSTOM_REGISTRY_REPO=bm-cluster-1-hyper.e2e.bos.redhat.com:5000/rhacm2
-export COMPOSITE_BUNDLE=true
-export DEBUG=true
-```
+	```sh
+	export DEFAULT_SNAPSHOT="2.3.0-DOWNSTREAM-2021-06-16-09-34-33"
+	export KUBECONFIG=/home/kni/ipv6/mgmt-hub/auth/kubeconfig
+	export CUSTOM_REGISTRY_REPO=bm-cluster-1-hyper.e2e.bos.redhat.com:5000/rhacm2
+	export COMPOSITE_BUNDLE=true
+	export DEBUG=true
+	```
 
 - Now we just need to execute the deployment script called `start.sh`
 
-When it finishes, we just need to check that all pods are in running state and the installation process take some time to finish so be patient.
+- When it finishes, we just need to check that all pods are in running state and the installation process take some time to finish so be patient.
+
+	```
+	oc get pods -n open-cluster-management
+	```
 
 - After the installation has finished you need to double check that the MultiClusterHub object has been annotated with your custom registry repo, otherwise the managed cluster won't be able to pull the required images.
 
-```sh
-# If you're using connected deployment:
-oc annotate mch multiclusterhub mch-imageRepository='quay.io:443/acm-d'
-# If you're using disconnected deployment:
-oc annotate mch multiclusterhub mch-imageRepository='bm-cluster-1-hyper.e2e.bos.redhat.com:5000/rhacm2'
-```
+	```sh
+	oc annotate mch multiclusterhub mch-imageRepository='bm-cluster-1-hyper.e2e.bos.redhat.com:5000/rhacm2'
+	```
 
 ## ACM Uninstall process
 


### PR DESCRIPTION
Restructure the doc to split the ACM downstream deployment connected/disconnected to make it clear for a beginner. 