### PR TITLE
adding opm credentials check and doc

### DIFF
--- a/docs/prerequirements/mirror-olm.md
+++ b/docs/prerequirements/mirror-olm.md
@@ -41,6 +41,8 @@ grpcurl -plaintext localhost:50051 api.Registry/ListPackages > packages.out
 
 The `packages.out` contains the reference to the operators in that snapshot image. Then we need to take note of the ones we wanna include it on the mirroring and put them in a list:
 
+**NOTE**: for private repository, `opm` needs the credentials file located at the default location `~/.docker/config.json`
+
 ```sh
 opm index prune \
     -f registry.redhat.io/redhat/redhat-operator-index:v4.7 \

--- a/tools/mirror-olm.sh
+++ b/tools/mirror-olm.sh
@@ -32,14 +32,14 @@ if [ $# -lt 1 ]; then
 fi
 
 mirror() {
-	# Check for credentials for OPM 
-  if [ ! -f ~/.docker/config.json ]
-  then
-    echo "ERROR: missing ~/.docker/config.json config"
-    exit 1
-  fi
-  
-  # Mirror redhat-operator index image
+# Check for credentials for OPM
+	if [ ! -f ~/.docker/config.json ]
+	then
+		echo "ERROR: missing ~/.docker/config.json config"
+    		exit 1
+  	fi
+
+# Mirror redhat-operator index image
 	if [ "${RH_OP}" = true ]; then
 		echo "opm index prune --from-index $RH_OP_INDEX --packages $RH_OP_PACKAGES --tag $LOCAL_REGISTRY/$LOCAL_REGISTRY_INDEX_TAG"
 		opm index prune --from-index $RH_OP_INDEX --packages $RH_OP_PACKAGES --tag $LOCAL_REGISTRY/$LOCAL_REGISTRY_INDEX_TAG

--- a/tools/mirror-olm.sh
+++ b/tools/mirror-olm.sh
@@ -32,8 +32,14 @@ if [ $# -lt 1 ]; then
 fi
 
 mirror() {
-	# Mirror redhat-operator index image
-
+	# Check for credentials for OPM 
+  if [ ! -f ~/.docker/config.json ]
+  then
+    echo "ERROR: missing ~/.docker/config.json config"
+    exit 1
+  fi
+  
+  # Mirror redhat-operator index image
 	if [ "${RH_OP}" = true ]; then
 		echo "opm index prune --from-index $RH_OP_INDEX --packages $RH_OP_PACKAGES --tag $LOCAL_REGISTRY/$LOCAL_REGISTRY_INDEX_TAG"
 		opm index prune --from-index $RH_OP_INDEX --packages $RH_OP_PACKAGES --tag $LOCAL_REGISTRY/$LOCAL_REGISTRY_INDEX_TAG

--- a/tools/mirror-olm.sh
+++ b/tools/mirror-olm.sh
@@ -32,14 +32,14 @@ if [ $# -lt 1 ]; then
 fi
 
 mirror() {
-# Check for credentials for OPM
+	# Check for credentials for OPM
 	if [ ! -f ~/.docker/config.json ]
 	then
 		echo "ERROR: missing ~/.docker/config.json config"
     		exit 1
   	fi
 
-# Mirror redhat-operator index image
+	# Mirror redhat-operator index image
 	if [ "${RH_OP}" = true ]; then
 		echo "opm index prune --from-index $RH_OP_INDEX --packages $RH_OP_PACKAGES --tag $LOCAL_REGISTRY/$LOCAL_REGISTRY_INDEX_TAG"
 		opm index prune --from-index $RH_OP_INDEX --packages $RH_OP_PACKAGES --tag $LOCAL_REGISTRY/$LOCAL_REGISTRY_INDEX_TAG


### PR DESCRIPTION
Signed-off-by: Eran Ifrach <eifrach@redhat.com>

### What changed:

1. adding to `mirror-olm.sh` check for credentials file
2. add information regarding the credentials in the documentation 
