### PR TITLE
Not all mirror operator images come from openshift4 namespace

### DIFF
--- a/docs/prerequirements/mirror-olm.md
+++ b/docs/prerequirements/mirror-olm.md
@@ -279,7 +279,7 @@ for packagemanifest in $(oc get packagemanifest -n openshift-marketplace -o name
   for package in $(oc get $packagemanifest -o jsonpath='{.status.channels[*].currentCSVDesc.relatedImages}' | sed "s/ /\n/g" | tr -d '[],' | sed 's/"/ /g') ; do
     echo
     echo "Package: ${package}"
-    skopeo copy docker://$package docker://$LOCAL_REGISTRY/$LOCAL_REGISTRY_IMAGE_TAG/openshift4-$(basename $package) --all --authfile $OCP_PULLSECRET_AUTHFILE
+    skopeo copy docker://$package docker://$LOCAL_REGISTRY/$LOCAL_REGISTRY_IMAGE_TAG/$(echo $package | awk -F'/' '{print $2}')-$(basename $package) --all --authfile $OCP_PULLSECRET_AUTHFILE
   done
 done
 

--- a/tools/mirror-olm.sh
+++ b/tools/mirror-olm.sh
@@ -113,7 +113,7 @@ mirror-olm() {
 		for package in $(oc get $packagemanifest -o jsonpath='{.status.channels[*].currentCSVDesc.relatedImages}' | sed "s/ /\n/g" | tr -d '[],' | sed 's/"/ /g'); do
 			echo
 			echo "Package: ${package}"
-			skopeo copy docker://$package docker://$LOCAL_REGISTRY/$LOCAL_REGISTRY_IMAGE_TAG/openshift4-$(basename $package) --all --authfile $OCP_PULLSECRET_AUTHFILE
+			skopeo copy docker://$package docker://$LOCAL_REGISTRY/$LOCAL_REGISTRY_IMAGE_TAG/$(echo $package | awk -F'/' '{print $2}')-$(basename $package) --all --authfile $OCP_PULLSECRET_AUTHFILE
 		done
 	done
 


### PR DESCRIPTION
For example:

From a just generared **manifests-redhat-operator-index-1636388999/imageContentSourcePolicy.yaml** file, we have:
```
  - mirrors:
    - registry.local:5000/olm/openshift4-ose-ptp-operator-metadata
    source: registry.redhat.io/openshift4/ose-ptp-operator-metadata
```

But also...

```
  - mirrors:
    - registry.local:5000/olm/rhacm2-tech-preview-lighthouse-coredns-rhel8
    source: registry.redhat.io/rhacm2-tech-preview/lighthouse-coredns-rhel8
```