### PR TITLE
Add skopeo copy to acm-d sync process

### DIFF
--- a/docs/prerequirements/acm-downstream-deployment-disconnected.md
+++ b/docs/prerequirements/acm-downstream-deployment-disconnected.md
@@ -46,7 +46,7 @@ rm -rf ${BUILD_FOLDER}
 echo
 echo ">>>>>>>>>>>>>>> Cloning the Index and Bundle images..."
 skopeo copy --authfile ${PULL_SECRET_JSON} docker://quay.io/acm-d/acm-custom-registry:${SNAPSHOT} docker://${LOCAL_REGISTRY}/rhacm2/acm-custom-registry:${SNAPSHOT} --all
-skopeo copy --authfile ${PULL_SECRET_JSON}  docker://quay.io/acm-d/acm-operator-bundle:${ACM_OP_BUNDLE} docker://${LOCAL_REGISTRY}/rhacm2/acm-operator-bundle:${ACM_OP_BUNDLE} --all
+skopeo copy --authfile ${PULL_SECRET_JSON} docker://quay.io/acm-d/acm-operator-bundle:${ACM_OP_BUNDLE} docker://${LOCAL_REGISTRY}/rhacm2/acm-operator-bundle:${ACM_OP_BUNDLE} --all
 
 # Generate Mapping.txt
 echo

--- a/docs/prerequirements/acm-downstream-deployment-disconnected.md
+++ b/docs/prerequirements/acm-downstream-deployment-disconnected.md
@@ -31,12 +31,13 @@ To do that, you will need to follow [this steps](https://gist.github.com/cdoan1/
 
 ```sh
 #!/bin/bash
-export PULL_SECRET_JSON=/home/kni/jparrill/pull_secret_acm.json
+export PULL_SECRET_JSON=~/pull-secret.json
 export LOCAL_REGISTRY=$(hostname):5000
 export SNAPSHOT=2.3.0-DOWNSTREAM-2021-06-16-09-34-33
 export ACM_OP_BUNDLE=v2.3.0-127
 export IMAGE_INDEX=quay.io/acm-d/acm-custom-registry
 export BUILD_FOLDER=./build
+export REMOTE_REGISTRY=quay.io:443/acm-d 
 
 # Clean previous tries
 rm -rf ${BUILD_FOLDER}
@@ -44,8 +45,8 @@ rm -rf ${BUILD_FOLDER}
 # Copy ACM Custom Registry index and bundle images
 echo
 echo ">>>>>>>>>>>>>>> Cloning the Index and Bundle images..."
-skopeo copy --authfile ${PULL_SECRET_JSON} --all docker://quay.io/acm-d/acm-custom-registry:${SNAPSHOT} docker://bm-cluster-1-hyper.e2e.bos.redhat.com:5000/rhacm2/acm-custom-registry:${SNAPSHOT}
-skopeo copy --authfile ${PULL_SECRET_JSON} --all docker://quay.io/acm-d/acm-operator-bundle:${ACM_OP_BUNDLE} docker://bm-cluster-1-hyper.e2e.bos.redhat.com:5000/rhacm2/acm-operator-bundle:${ACM_OP_BUNDLE}
+skopeo copy --authfile ${PULL_SECRET_JSON} docker://quay.io/acm-d/acm-custom-registry:${SNAPSHOT} docker://${LOCAL_REGISTRY}/rhacm2/acm-custom-registry:${SNAPSHOT} --all
+skopeo copy --authfile ${PULL_SECRET_JSON}  docker://quay.io/acm-d/acm-operator-bundle:${ACM_OP_BUNDLE} docker://${LOCAL_REGISTRY}/rhacm2/acm-operator-bundle:${ACM_OP_BUNDLE} --all
 
 # Generate Mapping.txt
 echo
@@ -53,16 +54,26 @@ echo ">>>>>>>>>>>>>>> Creating mapping assets..."
 oc adm -a ${PULL_SECRET_JSON} catalog mirror ${IMAGE_INDEX}:${SNAPSHOT} ${LOCAL_REGISTRY} --manifests-only --to-manifests=${BUILD_FOLDER}
 
 # Replace the upstream registry by the downstream one
-sed -i s#registry.redhat.io/rhacm2/#quay.io/acm-d/# ${BUILD_FOLDER}/mapping.txt
+sed -i s#registry.redhat.io/rhacm2/#${REMOTE_REGISTRY}/# ${BUILD_FOLDER}/mapping.txt
 
 # Mirror the images into your mirror registry.
 echo
 echo ">>>>>>>>>>>>>>> Mirroring images..."
-oc image mirror -f ${BUILD_FOLDER}/mapping.txt -a ${PULL_SECRET_JSON} --filter-by-os=.* --keep-manifest-list --continue-on-error=true
+#oc image mirror -f ${BUILD_FOLDER}/mapping.txt -a ${PULL_SECRET_JSON} --filter-by-os=.* --keep-manifest-list --continue-on-error=true
+
+echo ">>>>>>>>>>>>>>> Copying images via skopeo..."
+for image in $(cat ${BUILD_FOLDER}/mapping.txt)
+do
+    IFS='='
+    declare -a FIELDS=($image)
+    echo "skopeo copy --authfile ${PULL_SECRET_JSON} docker://${FIELDS[0]} docker://${FIELDS[1]} --all"
+    skopeo copy --authfile ${PULL_SECRET_JSON} docker://${FIELDS[0]} docker://${FIELDS[1]} --all
+done
 
 echo
 echo "export CUSTOM_REGISTRY_REPO=${LOCAL_REGISTRY}/rhacm2"
 echo "export DEFAULT_SNAPSHOT=${SNAPSHOT}"
+
 ```
 
 This takes like 30 mins maybe less and you need to check this 2 resources to fill the proper variables:

--- a/docs/prerequirements/acm-downstream-deployment-disconnected.md
+++ b/docs/prerequirements/acm-downstream-deployment-disconnected.md
@@ -59,7 +59,7 @@ sed -i s#registry.redhat.io/rhacm2/#${REMOTE_REGISTRY}/# ${BUILD_FOLDER}/mapping
 # Mirror the images into your mirror registry.
 echo
 echo ">>>>>>>>>>>>>>> Mirroring images..."
-#oc image mirror -f ${BUILD_FOLDER}/mapping.txt -a ${PULL_SECRET_JSON} --filter-by-os=.* --keep-manifest-list --continue-on-error=true
+oc image mirror -f ${BUILD_FOLDER}/mapping.txt -a ${PULL_SECRET_JSON} --filter-by-os=.* --keep-manifest-list --continue-on-error=true
 
 echo ">>>>>>>>>>>>>>> Copying images via skopeo..."
 for image in $(cat ${BUILD_FOLDER}/mapping.txt)

--- a/tools/acm-downstream-image-sync.sh
+++ b/tools/acm-downstream-image-sync.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-export PULL_SECRET_JSON=/home/kni/jparrill/pull_secret_acm.json
+export PULL_SECRET_JSON=~/pull-secret.json
 export LOCAL_REGISTRY=$(hostname):5000
 export SNAPSHOT=2.3.0-DOWNSTREAM-2021-06-16-09-34-33
 export ACM_OP_BUNDLE=v2.3.0-127
 export IMAGE_INDEX=quay.io/acm-d/acm-custom-registry
 export BUILD_FOLDER=./build
+export REMOTE_REGISTRY=quay.io:443/acm-d 
 
 # Clean previous tries
 rm -rf ${BUILD_FOLDER}
@@ -12,8 +13,8 @@ rm -rf ${BUILD_FOLDER}
 # Copy ACM Custom Registry index and bundle images
 echo
 echo ">>>>>>>>>>>>>>> Cloning the Index and Bundle images..."
-skopeo copy --authfile ${PULL_SECRET_JSON} --all docker://quay.io/acm-d/acm-custom-registry:${SNAPSHOT} docker://bm-cluster-1-hyper.e2e.bos.redhat.com:5000/rhacm2/acm-custom-registry:${SNAPSHOT}
-skopeo copy --authfile ${PULL_SECRET_JSON} --all docker://quay.io/acm-d/acm-operator-bundle:${ACM_OP_BUNDLE} docker://bm-cluster-1-hyper.e2e.bos.redhat.com:5000/rhacm2/acm-operator-bundle:${ACM_OP_BUNDLE}
+skopeo copy --authfile ${PULL_SECRET_JSON} docker://quay.io/acm-d/acm-custom-registry:${SNAPSHOT} docker://${LOCAL_REGISTRY}/rhacm2/acm-custom-registry:${SNAPSHOT} --all
+skopeo copy --authfile ${PULL_SECRET_JSON}  docker://quay.io/acm-d/acm-operator-bundle:${ACM_OP_BUNDLE} docker://${LOCAL_REGISTRY}/rhacm2/acm-operator-bundle:${ACM_OP_BUNDLE} --all
 
 # Generate Mapping.txt
 echo
@@ -21,13 +22,23 @@ echo ">>>>>>>>>>>>>>> Creating mapping assets..."
 oc adm -a ${PULL_SECRET_JSON} catalog mirror ${IMAGE_INDEX}:${SNAPSHOT} ${LOCAL_REGISTRY} --manifests-only --to-manifests=${BUILD_FOLDER}
 
 # Replace the upstream registry by the downstream one
-sed -i s#registry.redhat.io/rhacm2/#quay.io/acm-d/# ${BUILD_FOLDER}/mapping.txt
+sed -i s#registry.redhat.io/rhacm2/#${REMOTE_REGISTRY}/# ${BUILD_FOLDER}/mapping.txt
 
 # Mirror the images into your mirror registry.
 echo
 echo ">>>>>>>>>>>>>>> Mirroring images..."
 oc image mirror -f ${BUILD_FOLDER}/mapping.txt -a ${PULL_SECRET_JSON} --filter-by-os=.* --keep-manifest-list --continue-on-error=true
 
+echo ">>>>>>>>>>>>>>> Copying images via skopeo..."
+for image in $(cat ${BUILD_FOLDER}/mapping.txt)
+do
+    IFS='='
+    declare -a FIELDS=($image)
+    echo "skopeo copy --authfile ${PULL_SECRET_JSON} docker://${FIELDS[0]} docker://${FIELDS[1]} --all"
+    skopeo copy --authfile ${PULL_SECRET_JSON} docker://${FIELDS[0]} docker://${FIELDS[1]} --all
+done
+
 echo
 echo "export CUSTOM_REGISTRY_REPO=${LOCAL_REGISTRY}/rhacm2"
 echo "export DEFAULT_SNAPSHOT=${SNAPSHOT}"
+

--- a/tools/acm-downstream-image-sync.sh
+++ b/tools/acm-downstream-image-sync.sh
@@ -14,7 +14,7 @@ rm -rf ${BUILD_FOLDER}
 echo
 echo ">>>>>>>>>>>>>>> Cloning the Index and Bundle images..."
 skopeo copy --authfile ${PULL_SECRET_JSON} docker://quay.io/acm-d/acm-custom-registry:${SNAPSHOT} docker://${LOCAL_REGISTRY}/rhacm2/acm-custom-registry:${SNAPSHOT} --all
-skopeo copy --authfile ${PULL_SECRET_JSON}  docker://quay.io/acm-d/acm-operator-bundle:${ACM_OP_BUNDLE} docker://${LOCAL_REGISTRY}/rhacm2/acm-operator-bundle:${ACM_OP_BUNDLE} --all
+skopeo copy --authfile ${PULL_SECRET_JSON} docker://quay.io/acm-d/acm-operator-bundle:${ACM_OP_BUNDLE} docker://${LOCAL_REGISTRY}/rhacm2/acm-operator-bundle:${ACM_OP_BUNDLE} --all
 
 # Generate Mapping.txt
 echo


### PR DESCRIPTION
I was noticing occasion errors when syncing the acm-d bits to a disconnect registry. The skopeo copy seems to address this. 